### PR TITLE
Configure for deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "dev": "ts-node-dev src/server.ts",
-    "test": "jest"
+    "test": "jest",
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "dev": "ts-node-dev src/server.ts"
   },
   "devDependencies": {
     "@swc/core": "^1.2.177",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"
+  provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -97,5 +97,6 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
Configurações para deploy feitas na aula 5

Commits:
* Use postgres as database provider
* Make typescript ignore jest.config
* Add scripts for build and start in production